### PR TITLE
Automatic appcache creation

### DIFF
--- a/app.cache.manifest
+++ b/app.cache.manifest
@@ -1,36 +1,18 @@
 CACHE MANIFEST
-# Build 16
-
 
 CACHE:
-https://cdnjs.cloudflare.com/ajax/libs/es5-shim/4.1.14/es5-shim.min.js
-https://cdnjs.cloudflare.com/ajax/libs/es6-promise/3.0.2/es6-promise.min.js
-https://cdnjs.cloudflare.com/ajax/libs/fetch/0.10.0/fetch.min.js
+http://jsbench.github.io/bundles/js/jsbench.js
 http://jsbench.github.io/vendor/canvas-to-blob.js
-https://www.google.com/jsapi
-https://cdnjs.cloudflare.com/ajax/libs/ace/1.2.0/ace.min.js
-https://cdnjs.cloudflare.com/ajax/libs/ace/1.2.0/mode-javascript.js
-https://cdnjs.cloudflare.com/ajax/libs/ace/1.2.0/theme-tomorrow.js
-https://cdnjs.cloudflare.com/ajax/libs/platform/1.3.0/platform.min.js
-https://cdnjs.cloudflare.com/ajax/libs/benchmark/1.0.0/benchmark.min.js
-http://jsbench.github.io/vendor/oauth.min.js
 http://jsbench.github.io/vendor/feast.min.js
-https://cdnjs.cloudflare.com/ajax/libs/sweetalert/1.1.0/sweetalert.min.js
-https://cdn.firebase.com/js/client/2.3.1/firebase.js
-http://jsbench.github.io/src/btn.js
-http://jsbench.github.io/src/github.js
-http://jsbench.github.io/src/share.js
-http://jsbench.github.io/src/chart.js
-http://jsbench.github.io/src/editor.js
-http://jsbench.github.io/src/app.js
-https://buttons.github.io/buttons.js
+http://jsbench.github.io/vendor/oauth.min.js
 http://jsbench.github.io/st/app.css
-http://jsbench.github.io/st/facebook.svg
-http://jsbench.github.io/st/favicon.ico
-http://jsbench.github.io/st/google.svg
-http://jsbench.github.io/st/og-image.png
-http://jsbench.github.io/st/twitter.svg
-
+http://jsbench.github.io/st/images/facebook.svg
+http://jsbench.github.io/st/images/google.svg
+http://jsbench.github.io/st/images/twitter.svg
+http://jsbench.github.io/st/images/og-image.png
+http://jsbench.github.io/st/images/favicon.ico
 
 NETWORK:
 *
+
+# hash: f82010d4f34ec456bd14665500eab5b7db146820d862dcba1184a000ae609bea

--- a/gulp.config.js
+++ b/gulp.config.js
@@ -5,6 +5,8 @@ export default {
 	sourceDir: './src/',
 	buildDir: './bundles/',
 
+	cacheManifestName: 'app.cache.manifest',
+
 	browserSync: {
 		browserPort: 3000,
 		UIPort: 3001,

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -8,6 +8,9 @@ import babelify    from 'babelify';
 import source      from 'vinyl-source-stream';
 import notify      from 'gulp-notify';
 import browserSync from 'browser-sync';
+import manifest    from 'gulp-manifest';
+import path        from 'path';
+import mergeStream from 'merge-stream';
 
 function handleErrors() {
 	let args = Array.prototype.slice.call(arguments);
@@ -66,6 +69,29 @@ gulp.task('lint', () => {
 		.pipe(eslint.failOnError());
 });
 
+gulp.task('manifest', () => {
+	mergeStream(
+		gulp.src([
+			path.join('bundles/js/*.js'),
+			path.join('vendor/**/*.js'),
+			path.join('st/*.css'),
+			path.join('st/images/**/*.{svg,png,ico,jpg}')
+		], {
+			base: './'
+		})
+	)
+	.pipe(manifest({
+		prefix: 'http://jsbench.github.io/',
+		hash: true,
+		timestamp: false,
+		preferOnline: false,
+		network: ['*'],
+		filename: config.cacheManifestName,
+		exclude: config.cacheManifestName
+	 }))
+	.pipe(gulp.dest('./'));
+});
+
 gulp.task('browser-sync', () => {
 	browserSync.init({
 		server: {
@@ -79,5 +105,5 @@ gulp.task('browser-sync', () => {
 	});
 });
 
-gulp.task('build', ['lint', 'browserify']);
+gulp.task('build', ['lint', 'browserify', 'manifest']);
 gulp.task('default', ['build', 'browser-sync']);

--- a/package.json
+++ b/package.json
@@ -22,8 +22,13 @@
     "eslint": "^1.10.3",
     "gulp": "^3.9.0",
     "gulp-eslint": "^1.1.1",
+    "gulp-manifest": "^0.1.1",
     "gulp-notify": "^2.2.0",
     "vinyl-buffer": "^1.0.0",
     "vinyl-source-stream": "^1.1.0"
+  },
+  "dependencies": {
+    "merge-stream": "^1.0.0",
+    "path": "^0.12.7"
   }
 }


### PR DESCRIPTION
Более-менее автоматическое формирование `appcache manifest` файла. Единственное, чего не хватает, так это того, что он не может подтягивать сторонние ресурсы (?) Согласно документации:

> Resource URLs can be absolute or relative to the manifest file.

По крайней мере плагины, которые я пробовал, не хотят вставлять в манифест файлы со сторонних ресурсов ;[

Но, как только мы переведём все используемые в html зависимости на npm зависимые модули и будем использовать их по требованию, то такой проблемы не будет, т.к. данные файлы будут распологаться локально. Как считаешь?
