### PR TITLE
Enabling live js syntax checking

### DIFF
--- a/app.cache.manifest
+++ b/app.cache.manifest
@@ -15,4 +15,4 @@ http://jsbench.github.io/st/images/favicon.ico
 NETWORK:
 *
 
-# hash: 7d218e104eb8ee7511de4c45b600249d08257d39f456b3d507c2cf5316ae8922
+# hash: 0b0e1ffd99486cbaa672e523db8373129cbfbf2b843e9f71e2e2f8cf4e5051c8

--- a/index.html
+++ b/index.html
@@ -153,9 +153,7 @@
 <script src="//www.google.com/jsapi"></script>
 
 <!-- Ace -->
-<script src="//cdnjs.cloudflare.com/ajax/libs/ace/1.2.0/ace.min.js"></script>
-<script src="//cdnjs.cloudflare.com/ajax/libs/ace/1.2.0/mode-javascript.js"></script>
-<script src="//cdnjs.cloudflare.com/ajax/libs/ace/1.2.0/theme-tomorrow.js"></script>
+<script src="//cdnjs.cloudflare.com/ajax/libs/ace/1.2.2/ace.js"></script>
 
 <!-- Platform + Benchmark -->
 <script src="//cdnjs.cloudflare.com/ajax/libs/platform/1.3.0/platform.min.js"></script>


### PR DESCRIPTION
Fixes #14 

Live checking поддерживается и включён по дефолту. Проблема была с невозможностью загрузки файла `workers-javascript.js`.
1. Подключил последнюю версию ace.
2. Убрал подключения темы и режима, т.к. ace подгрузит их on demand.
3. Каким-то странным образом, либа `ace` с расширением `.min` не работает как следует. Но стоит подгрузить минифицированную либу без расширения `.min`, как всё работает как часы. 

И заодно починилась пробелма с загрузкой проекта в `Edge`, когда браузер не мог найти `workers-javascript.js` файл.

> Important! due to cross origin restrictions on webWorkers worker files must be served from the main domain.
> [https://github.com/ajaxorg/ace/wiki/Syntax-validation](https://github.com/ajaxorg/ace/wiki/Syntax-validation)
